### PR TITLE
webpack.config.web.prod: CopyPlugin wildcard changed from `*` to `**/*`...

### DIFF
--- a/src/webpack.config.web.prod.js
+++ b/src/webpack.config.web.prod.js
@@ -26,7 +26,7 @@ function prod() {
         template: Path.resolve(rootPath, "src/main/html/index.html"),
       }),
       new CopyPlugin({
-        patterns: [{from: "*", context: assetsDir}],
+        patterns: [{ from: "**/*", context: assetsDir }],
       }),
       new MiniCssExtractPlugin({
         filename: "main-[contenthash]-hashed.css",


### PR DESCRIPTION
... to include subdirectories in assets directory